### PR TITLE
Add utility workflow for get module's informations

### DIFF
--- a/.github/workflows/module-info.yml
+++ b/.github/workflows/module-info.yml
@@ -1,0 +1,53 @@
+name: "Retrieve NS8 module informations"
+
+on:
+  workflow_call:
+    outputs:
+      owner:
+        description: "The owner of the repository, that can an users or an organization"
+        value: ${{ jobs.module.outputs.owner}}
+      tag:
+        description: "The container's tag of the module"
+        value: ${{ jobs.module.outputs.tag }}
+      sha:
+        description: "The git commit hash of the current module version"
+        value: ${{ jobs.module.outputs.sha }}
+      short_sha:
+        description: "First 8 chars of the commit hash"
+        value: ${{ jobs.module.outputs.short_sha }}
+
+jobs:
+  module:
+    runs-on: ubuntu-latest
+    outputs:
+      owner: ${{ steps.owner.outputs.name }}
+      tag: ${{ steps.tag.outputs.name }}
+      sha: ${{ steps.sha.outputs.value }}
+      short_sha: ${{ steps.short_sha.outputs.value }}
+    steps:
+      - id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]
+          then
+            tag="${{ github.event.workflow_run.head_branch }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]
+          then
+            tag=${{ github.head_ref }}
+          else
+            tag="${{ github.ref_name }}"
+          fi
+          if [ "$tag" = "main" ]
+          then
+            tag="latest"
+          fi
+          echo "::set-output name=name::${tag}"
+      - id: owner
+        run: |
+          owner=$(basename ${{ github.event.organization.url || github.event.repository.owner.url }} |  tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=name::${owner}"
+      - id: sha
+        run: |
+          sha=${{ github.event.workflow_run.head_sha || github.sha }}
+          echo "::set-output name=value::${sha}"
+      - id: short_sha
+        run: echo "::set-output name=value::$( echo ${{ steps.sha.outputs.value }} | cut -c1-8 )"


### PR DESCRIPTION
The `module-info.yml` workflow will provide the following outputs:
  * `owner`: the owner of the repository, that can an users or an
    organization
  * `tag`: the container's tag of the module
  * `sha`: the git commit hash of the current module version.
  * `short_sha`: first 8 chars of the commit hash
