### PR TITLE
Add workflow for setup test clusters on DigitalOcean cloud infrastructure

### DIFF
--- a/.github/workflows/test-on-digitalocean-infra.yml
+++ b/.github/workflows/test-on-digitalocean-infra.yml
@@ -1,0 +1,160 @@
+name: "Setup NS8 clusters on DigitalOcean and test module"
+
+on:
+  workflow_call:
+    inputs:
+      script:
+        required: false
+        description: "Name of the script to execute"
+        type: string
+        default: test-module.sh
+      path:
+        required: false
+        type: string
+        description: "Name of the script to execute, default `test-module.sh`"
+      args:
+        required: false
+        type: string
+        description: "Path where is located the script"
+      repo_ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+        description: "Additional arguments to pass to the script"
+      debug_shell:
+        required: false
+        type: boolean
+        default: false
+        description: "Obtain a debug shell via https://tmate.io/"
+      coremodules:
+        required: false
+        type: string
+        description: "List of space-separated module URL to pull and use during the NS8 installation process"
+      corebranch:
+        required: false
+        type: string
+        default: main
+        description: "Branch of the `ns8-core` repository from where get the installation script"
+      setup_cluster:
+        required: false
+        type: boolean
+        default: true
+        description: "If true the workflow will install and setup a NS8 cluster"
+      leader_nodes:
+        required: false
+        type: string
+        default: "cs1 dn1"
+        description: "List of space-separated leader nodes to create"
+      do_project:
+        required: false
+        type: string
+        default: "NS8-CI"
+        description: "DigitalOcean project where to create the droplets"
+      do_domain:
+        required: false
+        type: string
+        default: "ci.nethserver.net"
+        description: "DigitalOcean domain where to create the DNS records"
+    secrets:
+      do_token:
+        required: true
+        description: "DigitalOcean token to use for create the infrastructure"
+env:
+  TF_VAR_project: ${{ inputs.do_project }}
+  TF_VAR_domain: ${{ inputs.do_domain }}
+
+jobs:
+  info:
+    name: "Find NS8 cluster informations"
+    runs-on: ubuntu-latest
+    outputs:
+      nodes: ${{ steps.nodes.outputs.list }}
+      short_sha: ${{ steps.short_sha.outputs.value }}
+    steps:
+      - name: "Create the list of leader nodes"
+        id: nodes
+        run: |
+          nodes=$(jq -ncR '[inputs]' <<< "$(echo ${{ inputs.leader_nodes }} | tr ' ' '\n')")
+          echo "::set-output name=list::${nodes}"
+      - name: "Get the short sha of the current commit"
+        id: short_sha
+        run: echo "::set-output name=value::$( echo ${{ inputs.repo_ref }} | cut -c1-8 )"
+  test-module:
+    name: "Test on DigitalOcean"
+    runs-on: ubuntu-latest
+    needs: info
+    strategy:
+      fail-fast: false
+      matrix:
+          node: ${{ fromJSON(needs.info.outputs.nodes) }}
+    steps:
+      - name: "Checkout the module repository"
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.repo_ref }}
+          path: module
+      - name: "Checkout the infrastructure repository"
+        uses: actions/checkout@v3
+        with:
+          repository: NethServer/ns8-terraform-infra
+          path: infra
+      - name: "HashiCorp - Setup Terraform"
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_wrapper: false
+      - name: "HashiCorp - Terraform Apply"
+        env:
+          TF_VAR_do_token: ${{ secrets.do_token }}
+        run: |
+          terraform init
+          terraform workspace new ${{ matrix.node }}-${{ needs.info.outputs.short_sha }}
+          terraform apply -var 'leader_node={"${{ matrix.node }}":"ams3"}' -auto-approve
+        working-directory: ${{ github.workspace }}/infra
+      - name: "HashiCorp - Terraform Output Deploy Key"
+        run: |
+          terraform output -raw deploy-key > ${{ github.workspace }}/key
+          chmod 700 ${{ github.workspace }}/key
+        working-directory: ${{ github.workspace }}/infra
+      - name: "Wait for SSH server do be READY"
+        run: |
+          for (( n=1; c<=20; c++ )); do
+          set +e
+            ssh -o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -i ${{ github.workspace }}/key \
+              root@${{ matrix.node }}.leader.${{ matrix.node }}-${{ needs.info.outputs.short_sha }}.${{ env.TF_VAR_domain }} true
+            if [ "$?" = "0" ]; then exit 0; fi
+            sleep 1
+          done
+          exit 1
+      - name: "Setup NS8 Cluster"
+        if: inputs.setup_cluster
+        run: |
+          ssh -o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -i ${{ github.workspace }}/key \
+          root@${{ matrix.node }}.leader.${{ matrix.node }}-${{ needs.info.outputs.short_sha }}.${{ env.TF_VAR_domain }} << EOF
+            set -e -x
+            curl -O https://raw.githubusercontent.com/NethServer/ns8-core/${{ inputs.corebranch }}/core/install.sh
+            sudo -E PATH=$PATH HOME=/root bash install.sh ${{ inputs.coremodules }}
+            sudo create-cluster $(hostname -f):55820 10.5.4.0/24 Nethesis,1234
+          EOF
+      - name: "Run tests"
+        run: |
+          ./${{ inputs.script }} ${{ matrix.node }}.leader.${{ matrix.node }}-${{ needs.info.outputs.short_sha }}.${{ env.TF_VAR_domain }} ${{ inputs.args }}
+        working-directory: ${{ github.workspace }}/module/${{ inputs.path }}
+        env:
+          SSH_KEYFILE: ${{ github.workspace }}/key
+          COREMODULES: ${{ inputs.coremodules }}
+      - name: "Save tests results"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-logs-${{ matrix.node }}
+          path: |
+             ${{ github.workspace }}/module/${{ inputs.path }}/tests/outputs/
+      - name: "Debugging with tmate"
+        if: ${{ inputs.debug_shell == true && ! cancelled() && always() }}
+        uses: mxschmitt/action-tmate@v3.1
+      - name: "HashiCorp - Terraform Destroy"
+        if: ${{ always() }}
+        env:
+          TF_VAR_do_token: ${{ secrets.do_token }}
+        run: terraform apply -destroy -auto-approve
+        working-directory: ${{ github.workspace }}/infra


### PR DESCRIPTION
The workflow will install and initialize a series of NS8 clusters on the DigitalOcean cloud infrastructure and then execute the `test-module.sh` script. The first argument passed will be always the hostname of the runner and the outputs of the tests will be uploaded as artifacts.

**Inputs**
* `script`: name of the script to execute, default `test-module.sh`
* `path`: path where is located the script, default the root of repository.
* `args`: additional arguments to pass to the script.
* `repo_ref`: Git ref to checkout for the tests code, default `github.sha`.
* `debug_shell`: set to true to obtain a debug shell via https://tmate.io/, default `false`.
* `coremodules`: list of space-separated module URL to pull and use during the NS8 installation process.
* `corebranch`: branch of the `ns8-core` repository from where get the installation script.
* `leader_nodes`: list of space-separated leader nodes to create, default  'cs1 dn1`.
* `setup_cluster`: if true the workflow will install and setup a NS8 cluster, default `true`.
* `do_project`: DigitalOcean project where to create the droplets, default `NS8-CI`.
* `do_domain`: DigitalOcean domain where to create the DNS records, default `ci.nethserver.net`

**Secrets**
* do_token: DigitalOcean token to use for creating the infrastructure.

**Examples**
* `ns8-core` module: NethServer/ns8-core#230
* Core modules: NethServer/ns8-traefik#6