### PR TITLE
Cancel running workflow on a new push

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   publish_images:
     name: 'Publish module images'

--- a/.github/workflows/test-on-digitalocean-infra.yml
+++ b/.github/workflows/test-on-digitalocean-infra.yml
@@ -63,6 +63,10 @@ env:
   TF_VAR_project: ${{ inputs.do_project }}
   TF_VAR_domain: ${{ inputs.do_domain }}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   info:
     name: "Find NS8 cluster informations"


### PR DESCRIPTION
When many PR are merged in sequence, canceling the previous workflow (still running) saves time and resources.