### PR TITLE
Allow multiple execution of testing workflow

### DIFF
--- a/.github/workflows/test-on-digitalocean-infra.yml
+++ b/.github/workflows/test-on-digitalocean-infra.yml
@@ -63,9 +63,6 @@ env:
   TF_VAR_project: ${{ inputs.do_project }}
   TF_VAR_domain: ${{ inputs.do_domain }}
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   info:
@@ -84,6 +81,9 @@ jobs:
         id: short_sha
         run: echo "value=$( echo ${{ inputs.repo_ref }} | cut -c1-8 )" >> $GITHUB_OUTPUT
   test-module:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}-${{ matrix.node }}
+      cancel-in-progress: true
     name: "Test on DigitalOcean"
     runs-on: ubuntu-latest
     needs: info


### PR DESCRIPTION
Previously the parallel execution per repo was limited to only one per repo. For allowing one execution per branch and for explicit execution, three variables are added to the grouping policy:

- `github.ref_name`: the name of the branch if the workflow was called by the `workflow_dispatch` event, `main` if the workflow is called by `workflow_run` event.
- `github.event.workflow_run.head_branch`:  the branch name from where the workflow was called in case of `workflow_run`, empty otherwise.
- `matrix.node`: the base OS on where the NS8 is installed.

The `concurrency` keyword is moved from `workflow` to the `jobs` level, otherwise the `github.event.workflow_run.head_branch` variable is inaccessible.