### PR TITLE
Add GitHub Workflow for Container Scanning and SBOM Generation Using Trivy

### DIFF
--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -1,0 +1,32 @@
+name: "Analyze images with Trivy"
+
+on:
+  workflow_call:
+    inputs:
+      images:
+        description: "List of images to analyze"
+        required: true
+        type: string
+
+permissions:
+  security-events: write
+
+jobs:
+  trivy:
+    name: "Run Trivy vulnerability scanner"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(inputs.images) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -7,6 +7,11 @@ on:
         description: "List of images to analyze"
         required: true
         type: string
+      severity:
+        description: "Severities of vulnerabilities to scan for and display"
+        required: false
+        type: string
+        default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
 permissions:
   security-events: write
@@ -24,8 +29,10 @@ jobs:
         uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ matrix.image }}
+          severity: ${{ inputs.severity }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          limit-severities-for-sarif: true
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -7,6 +7,10 @@ on:
         description: "List of images to analyze"
         required: true
         type: string
+      generate_sbom:
+        description: "Generate SBOM"
+        type: boolean
+        default: true
       update_dependencies_graph:
         description: "Update GitHub Dependency Graph"
         type: boolean
@@ -55,3 +59,22 @@ jobs:
           format: github
           output: sbom.github.json
           github-pat: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate CycloneDX SBOM
+        if: ${{inputs.generate_sbom == true}}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: cyclonedx
+          output: sbom-${{ github.run_id }}-${{ github.run_attempt }}.cdx.json
+      - name: Set safe filename
+        if: ${{inputs.generate_sbom == true}}
+        id: safe-filename
+        run: |
+          SAFE_NAME=$(echo "${{ matrix.image }}" | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "safe_name=${SAFE_NAME}" >> $GITHUB_OUTPUT
+      - name: Upload CycloneDX SBOM
+        if: ${{inputs.generate_sbom == true}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.safe-filename.outputs.safe_name }}-cyclonedx-sbom
+          path: sbom-${{ github.run_id }}-${{ github.run_attempt }}.cdx.json

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -33,9 +33,6 @@ on:
         type: string
         default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
-permissions:
-  security-events: write
-
 jobs:
   scan_ui_imageroot:
     name: "Scan module UI and imageroot"

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -7,6 +7,14 @@ on:
         description: "List of images to analyze"
         required: true
         type: string
+      scan_module_ui:
+        description: "Scan module UI"
+        type: boolean
+        default: true
+      scan_module_imageroot:
+        description: "Scan module imageroot"
+        type: boolean
+        default: true
       generate_sbom:
         description: "Generate SBOM"
         type: boolean
@@ -29,6 +37,59 @@ permissions:
   security-events: write
 
 jobs:
+  scan_ui_imageroot:
+    name: "Scan module UI and imageroot"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "ui"
+            path: ./ui
+            scan_enabled: ${{ inputs.scan_module_ui }}
+          - name: "imageroot"
+            path: ./imageroot
+            scan_enabled: ${{ inputs.scan_module_imageroot }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run vulnerability scanner
+        if: ${{matrix.scan_enabled == true && inputs.vulnerability_scan == true}}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ matrix.path }}
+          severity: ${{ inputs.severity }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          limit-severities-for-sarif: true
+      - name: Upload scan results to GitHub Security tab
+        if: ${{matrix.scan_enabled == true && inputs.vulnerability_scan == true}}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+      - name: Update GitHub Dependency Graph
+        if: ${{matrix.scan_enabled == true && inputs.update_dependencies_graph == true}}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ matrix.path }}
+          format: github
+          output: sbom.github.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate CycloneDX SBOM
+        if: ${{matrix.scan_enabled == true && inputs.generate_sbom == true}}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ matrix.path }}
+          format: cyclonedx
+          output: ${{ matrix.name }}.cdx.json
+      - name: Upload CycloneDX SBOM
+        if: ${{matrix.scan_enabled == true && inputs.generate_sbom == true}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}-cyclonedx-sbom
+          path: ${{ matrix.name }}.cdx.json
   scan_images:
     name: "Scan images"
     runs-on: ubuntu-latest

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -7,6 +7,10 @@ on:
         description: "List of images to analyze"
         required: true
         type: string
+      vulnerability_scan:
+        description: "Run vulnerability scan"
+        type: boolean
+        default: true
       severity:
         description: "Severities of vulnerabilities to scan for and display"
         required: false
@@ -17,15 +21,16 @@ permissions:
   security-events: write
 
 jobs:
-  trivy:
-    name: "Run Trivy vulnerability scanner"
+  scan_images:
+    name: "Scan images"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image: ${{ fromJson(inputs.images) }}
     steps:
-      - name: Run Trivy vulnerability scanner
+      - name: Run vulnerability scanner
+        if: ${{inputs.vulnerability_scan == true}}
         uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ matrix.image }}
@@ -33,7 +38,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           limit-severities-for-sarif: true
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload scan results to GitHub Security tab
+        if: ${{inputs.vulnerability_scan == true}}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -7,6 +7,10 @@ on:
         description: "List of images to analyze"
         required: true
         type: string
+      update_dependencies_graph:
+        description: "Update GitHub Dependency Graph"
+        type: boolean
+        default: true
       vulnerability_scan:
         description: "Run vulnerability scan"
         type: boolean
@@ -43,3 +47,11 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+      - name: Update GitHub Dependency Graph
+        if: ${{inputs.update_dependencies_graph == true}}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: github
+          output: sbom.github.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-with-trivy.yml
+++ b/.github/workflows/scan-with-trivy.yml
@@ -87,6 +87,21 @@ jobs:
         with:
           name: ${{ matrix.name }}-cyclonedx-sbom
           path: ${{ matrix.name }}.cdx.json
+      - name: Upload SBOM to GitHub Release
+        if: ${{matrix.scan_enabled == true && inputs.generate_sbom == true && startsWith(github.ref, 'refs/tags/')}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Check if this tag has a corresponding GitHub release
+          if gh release view "$TAG_NAME" &>/dev/null; then
+            echo "Release for tag $TAG_NAME found. Uploading SBOM file..."
+            gh release upload "$TAG_NAME" "${{ matrix.name }}.cdx.json" \
+              --clobber --repo ${{ github.repository }}
+          else
+            echo "No release found for tag $TAG_NAME. Skipping SBOM upload."
+          fi
+
   scan_images:
     name: "Scan images"
     runs-on: ubuntu-latest
@@ -136,3 +151,21 @@ jobs:
         with:
           name: ${{ steps.safe-filename.outputs.safe_name }}-cyclonedx-sbom
           path: sbom-${{ github.run_id }}-${{ github.run_attempt }}.cdx.json
+      - name: Upload SBOM to GitHub Release
+        if: ${{inputs.generate_sbom == true && startsWith(github.ref, 'refs/tags/')}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          FILE_PATH: sbom-${{ github.run_id }}-${{ github.run_attempt }}.cdx.json
+        run: |
+          # rename the file to the a safe name
+          mv $FILE_PATH "${{ steps.safe-filename.outputs.safe_name }}.cdx.json"
+          # Check if this tag has a corresponding GitHub release
+          if gh release view "$TAG_NAME" &>/dev/null; then
+            echo "Release for tag $TAG_NAME found. Uploading SBOM file..."
+            gh release upload "$TAG_NAME" \
+              "${{ steps.safe-filename.outputs.safe_name }}.cdx.json" \
+              --clobber --repo ${{ github.repository }}
+          else
+            echo "No release found for tag $TAG_NAME. Skipping SBOM upload."
+          fi


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that leverages Trivy to
enhance the security posture of our project by automating vulnerability
scanning and Software Bill of Materials (SBOM) generation. By integrating this
workflow, we aim to proactively identify vulnerabilities in container images
and code repositories, ensuring compliance with best practices and improving
visibility into dependencies and their security status.

The workflow provides flexibility with configurable inputs, enabling targeted
scanning of specific components (`ui`, `imageroot`) or container images. It
supports key actions such as vulnerability detection, updating the GitHub
Dependency Graph, and generating CycloneDX SBOMs, which are uploaded as
artifacts or attached to GitHub releases when applicable.


### Inputs:
1. **`images`**: A JSON array representing the list of container
   images to scan.
2. **`scan_module_ui`**: A boolean flag to enable/disable scanning of the module UI
   (default: `true`).
3. **`scan_module_imageroot`**: A boolean flag to enable/disable scanning of
   the module imageroot (default: `true`).
4. **`generate_sbom`**: A boolean flag to enable/disable SBOM generation
   (default: `true`).
5. **`update_dependencies_graph`**: A boolean flag to enable/disable the
   updating of the GitHub Dependency Graph (default: `true`).
6. **`vulnerability_scan`**: A boolean flag to enable/disable vulnerability
   scanning (default: `true`).
7. **`severity`**: A comma-separated string of severity levels to include in
   the scan results (default: `"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"`).

### Outputs:
1. **Vulnerability Scan Results**:
   - Format: SARIF
   - Location: Uploaded to the GitHub Security tab.

2. **SBOM Files**:
   - Format: CycloneDX (JSON).
   - Location:
     - Uploaded as artifacts to the workflow run.
     - Optionally attached to GitHub releases if a tag triggers the workflow.

3. **Dependency Graph Updates**:
   - Dependency data is pushed to the GitHub Dependency Graph for enhanced
     visibility.

### Calling workflow permissions
```yaml
# Required permissions for various operations
permissions:
  packages: write     # For publishing container images
  actions: read      # For reading workflow runs
  contents: write    # For creating releases and uploading assets
  security-events: write  # For uploading security scan results
```

### Usage

The workflow can be used in two ways for running Trivy security scans. It can
be simply included as a job into the existing "Publish images" workflow, where
it runs after other jobs finish up. Or it can be set up as a separate workflow
that automatically triggers when image publishing is complete. 

Both approaches are effective - the first keeps everything together in one
pipeline, while the second allows for independent management of security
scanning separate from the main build process. 

However, one disadvantage of the second method is that the workflow will always
appear as executed in the GitHub Actions list after the publish workflow, even
when the scan is not actually performed. This can create misleading entries in
the workflow history compared to the integrated approach.

In both methods the job runs if the output from the `module` job indicates that
the release is either `stable` or `latest`, or if the workflow was manually
triggered (`workflow_dispatch`). It passes two parameters to this workflow: the
images to be scanned, which are outputs from the `module` job, and the severity
levels to be reported.

#### Example 1: Called as a job inside the `Publish images` workflow
```yaml
name: "Publish images"

on:
  push:
  workflow_dispatch:

permissions:
  packages: write
  actions: read
  contents: write
  security-events: write

jobs:
  publish-images:
    if: github.run_number > 1
    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
  module:
    needs: publish-images
    uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@vi
  trivy:
    needs: module
    if: ${{ needs.module.outputs.release == 'stable' || needs.module.outputs.release == 'latest' || github.event_name == 'workflow_dispatch' }}
    uses: NethServer/ns8-github-actions/.github/workflows/scan-with-trivy.yml@v1
    with:
      images: ${{ needs.module.outputs.images }}
```

#### Example 2: Called at the end of the `Publish images` workflow
```yaml
name: Analyze module

on:
  workflow_dispatch:
  workflow_run:
    workflows: ["Publish images"]
    types:
      - completed

permissions:
  packages: write
  actions: read
  contents: write
  security-events: write

jobs:
  module:
    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == '' }}
    uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@v1
  trivy:
    needs: module
    if: ${{ needs.module.outputs.release == 'stable' || needs.module.outputs.release == 'latest' || github.event_name == 'workflow_dispatch' }}
    uses: NethServer/ns8-github-actions/.github/workflows/scan-with-trivy.yml@v1
    with:
      images: ${{ needs.module.outputs.images }}
      severities: "HIGH,CRITICAL"
```
##### Instructions
1. Create a directory named `.github/workflows` at the root of your repository
   if it doesn't already exist.
2. Inside the `.github/workflows` directory, create a new YAML file, `analyze-module.yml`.
3. Copy and paste the YAML configuration into the `analyze-module.yml` file.
4. Commit and push the file to your repository.
---
* Depends on #25 