### PR TITLE
Avoid docker.io rate limit failures

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -37,6 +37,14 @@ jobs:
           key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
       - id: build
         run: |
+          # Try NethServer mirrors before going to docker.io to avoid rate-limits
+          mkdir -vp /etc/containers/registries.conf.d
+          cat - >/etc/containers/registries.conf.d/800-nethserver.conf <<'EOF'
+          [[registry]]
+          location = "docker.io"
+          [[registry.mirror]]
+          location = "ghcr.io/nethserver/docker.io"
+          EOF
           # Write .netrc file with the secret contents:
           ( umask 077 ; base64 -d <<<"${{ secrets.netrcb64 }}" >~/.netrc || : ; )
           # Build the module images


### PR DESCRIPTION
Try NethServer mirror on ghcr.io before going to docker.io. This configuration is applied to Podman Buildah and Skopeo tools.

Refs NethServer/dev#7160