### PR TITLE
fix(trivy): filter out empty image items

### DIFF
--- a/.github/workflows/module-info.yml
+++ b/.github/workflows/module-info.yml
@@ -84,7 +84,7 @@ jobs:
           podman pull ${{ steps.image.outputs.name }}
           images=$(podman image inspect ${{ steps.image.outputs.name }}  \
               -f '{{index .Config.Labels "org.nethserver.images"}}' | \
-            jq -Rc '(split("\\s+";null) + ["${{ steps.image.outputs.name }}"])')
+            jq -Rc '(gsub("^\\s+|\\s+$"; "") | split("\\s+";null) + ["${{ steps.image.outputs.name }}"])')
 
           echo "list=${images}" >> $GITHUB_OUTPUT
       - name: Check release type


### PR DESCRIPTION
When the images string is converted to a JSON array, trim spaces to prevent the return of empty strings in the array list.


Refs https://github.com/NethServer/ns8-mail/actions/runs/14247457861/job/39932028916#step:2:135

Discussion https://mattermost.nethesis.it/nethesis/pl/ciytbbnubpb3igdogt7obwhwre