### PR TITLE
fix: sanitize IMAGETAG

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -50,8 +50,8 @@ jobs:
           buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
           images=(${{ steps.build.outputs.images }})
           urls=""
-          : ${IMAGETAG:?}
-          # Sanitize tag syntax: slash are not allowed
+          : "${IMAGETAG:?}"
+          # Sanitize tag syntax: slashes are not allowed
           imagetag=$(echo $IMAGETAG | tr / -)
           for image in "${images[@]}" ; do
             buildah push $image docker://${image}:${imagetag}

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -50,11 +50,14 @@ jobs:
           buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
           images=(${{ steps.build.outputs.images }})
           urls=""
+          : ${IMAGETAG:?}
+          # Sanitize tag syntax: slash are not allowed
+          imagetag=$(echo $IMAGETAG | tr / -)
           for image in "${images[@]}" ; do
-            buildah push $image docker://${image}:${IMAGETAG:?}
-            if [[ "${IMAGETAG}" == "main" || "${IMAGETAG}" == "master" ]]; then
+            buildah push $image docker://${image}:${imagetag}
+            if [[ "${imagetag}" == "main" || "${imagetag}" == "master" ]]; then
                 buildah push $image docker://${image}:latest
             fi
-            urls="${image}:${IMAGETAG} "$'\n'"${urls}"
+            urls="${image}:${imagetag} "$'\n'"${urls}"
           done
           echo "::notice title=Image URLs::${urls}"

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -52,7 +52,7 @@ jobs:
           urls=""
           : "${IMAGETAG:?}"
           # Sanitize tag syntax: slashes are not allowed
-          imagetag=$(echo $IMAGETAG | tr / -)
+          imagetag=$(printf '%s' "${IMAGETAG}" | tr '/' '-')
           for image in "${images[@]}" ; do
             buildah push $image docker://${image}:${imagetag}
             if [[ "${imagetag}" == "main" || "${imagetag}" == "master" ]]; then


### PR DESCRIPTION
Many tools use the "/" slash char in branch names, which is not allowed in container image tags. Replace "/" with "-" in the branch name to build the image tag.