### PR TITLE
Add optional extra cache inputs to publish-branch workflow

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      extra-cache-paths:
+        description: 'Additional file paths to cache between runs (multiline, one path per line)'
+        required: false
+        default: ''
+        type: string
+      extra-cache-key:
+        description: 'Cache key for the extra paths'
+        required: false
+        default: ''
+        type: string
     secrets:
       netrcb64:
         description: "Netrc Base64-encoded file content for authenticated downloads. Overrides netrc secret."
@@ -35,6 +45,11 @@ jobs:
         with:
           path: ui/node_modules
           key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
+      - uses: actions/cache@v5
+        if: inputs.extra-cache-paths != ''
+        with:
+          path: ${{ inputs.extra-cache-paths }}
+          key: ${{ inputs.extra-cache-key }}
       - id: build
         run: |
           # Write .netrc file with the secret contents:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -14,12 +14,12 @@ on:
         default: ''
         type: string
       extra-cache-key-prefix:
-        description: 'Prefix for the extra cache key (e.g. "maven-build")'
+        description: 'Prefix string for the extra cache key'
         required: false
         default: ''
         type: string
       extra-cache-key-file:
-        description: 'File to hash to generate the extra cache key (e.g. "webtop5-build/VERSION")'
+        description: 'File whose content is hashed to generate the extra cache key. A version file is a good candidate.'
         required: false
         default: ''
         type: string

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           KEY_FILE: ${{ inputs.extra-cache-key-file }}
           KEY_PREFIX: ${{ inputs.extra-cache-key-prefix }}
-        run: echo "key=${KEY_PREFIX}-$(sha256sum "${KEY_FILE}" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: printf 'key=%s-%s\n' "$KEY_PREFIX" "$(sha256sum "$KEY_FILE" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         if: inputs.extra-cache-paths != ''
         with:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -13,8 +13,13 @@ on:
         required: false
         default: ''
         type: string
-      extra-cache-key:
-        description: 'Cache key for the extra paths'
+      extra-cache-key-prefix:
+        description: 'Prefix for the extra cache key (e.g. "maven-build")'
+        required: false
+        default: ''
+        type: string
+      extra-cache-key-file:
+        description: 'File to hash to generate the extra cache key (e.g. "webtop5-build/VERSION")'
         required: false
         default: ''
         type: string
@@ -45,11 +50,17 @@ jobs:
         with:
           path: ui/node_modules
           key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
+      - id: extra-cache-key
+        if: inputs.extra-cache-paths != ''
+        env:
+          KEY_FILE: ${{ inputs.extra-cache-key-file }}
+          KEY_PREFIX: ${{ inputs.extra-cache-key-prefix }}
+        run: echo "key=${KEY_PREFIX}-$(sha256sum "${KEY_FILE}" | awk '{print $1}')" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         if: inputs.extra-cache-paths != ''
         with:
           path: ${{ inputs.extra-cache-paths }}
-          key: ${{ inputs.extra-cache-key }}
+          key: ${{ steps.extra-cache-key.outputs.key }}
       - id: build
         run: |
           # Write .netrc file with the secret contents:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -55,7 +55,20 @@ jobs:
         env:
           KEY_FILE: ${{ inputs.extra-cache-key-file }}
           KEY_PREFIX: ${{ inputs.extra-cache-key-prefix }}
-        run: printf 'key=%s-%s\n' "$KEY_PREFIX" "$(sha256sum "$KEY_FILE" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -z "${KEY_FILE// }" ]; then
+            hash='no-key-file'
+          elif [ ! -f "$KEY_FILE" ]; then
+            echo "::error::inputs.extra-cache-key-file was provided, but the file does not exist or is not a regular file: $KEY_FILE"
+            exit 1
+          else
+            hash=$(sha256sum "$KEY_FILE" | awk '{print $1}')
+          fi
+          if [ -z "$KEY_PREFIX" ]; then
+            echo "key=${hash}" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=${KEY_PREFIX}-${hash}" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/cache@v5
         if: inputs.extra-cache-paths != ''
         with:


### PR DESCRIPTION
Add three optional inputs to `publish-branch.yml` to allow callers to cache additional build artifacts between CI runs:

- `extra-cache-paths`: multiline list of file paths to cache
- `extra-cache-key-prefix`: prefix string for the cache key
- `extra-cache-key-file`: file whose content is hashed to generate the cache key (a version file is a good candidate)

The cache step is skipped when `extra-cache-paths` is empty, so existing callers are unaffected.

This is needed by ns8-webtop to cache Maven build artifacts ([NethServer/ns8-webtop#231](https://github.com/NethServer/ns8-webtop/pull/231)).