### PR TITLE
ci: fix tag before passing it to build-images.sh

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -42,6 +42,14 @@ jobs:
           # Build the module images
           REPOBASE=${REPOBASE,,}
           export REPOBASE
+          # Sanitize tag syntax: slashes are not allowed
+          # Abort if IMAGETAG is unset or empty
+          : "${IMAGETAG:?}"
+          # Replace '/' with '-'
+          IMAGETAG=$(printf '%s' "${IMAGETAG}" | tr '/' '-')
+          # Make sanitized value available to build-images.sh and subsequent steps
+          export IMAGETAG
+          echo "IMAGETAG=${IMAGETAG}" >> "$GITHUB_ENV"
           bash build-images.sh
       - id: publish
         run: |
@@ -50,14 +58,11 @@ jobs:
           buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
           images=(${{ steps.build.outputs.images }})
           urls=""
-          : "${IMAGETAG:?}"
-          # Sanitize tag syntax: slashes are not allowed
-          imagetag=$(printf '%s' "${IMAGETAG}" | tr '/' '-')
           for image in "${images[@]}" ; do
-            buildah push $image docker://${image}:${imagetag}
-            if [[ "${imagetag}" == "main" || "${imagetag}" == "master" ]]; then
+            buildah push $image docker://${image}:${IMAGETAG}
+            if [[ "${IMAGETAG}" == "main" || "${IMAGETAG}" == "master" ]]; then
                 buildah push $image docker://${image}:latest
             fi
-            urls="${image}:${imagetag} "$'\n'"${urls}"
+            urls="${image}:${IMAGETAG} "$'\n'"${urls}"
           done
           echo "::notice title=Image URLs::${urls}"


### PR DESCRIPTION
This pull request updates the `publish-branch.yml` workflow to improve the handling and sanitization of the `IMAGETAG` environment variable. The main goal is to ensure that image tags are valid and consistently available throughout the workflow steps.

**Improvements to image tag handling:**

* Ensured that `IMAGETAG` is set and non-empty before proceeding, causing the workflow to fail early if not provided.
* Sanitized the `IMAGETAG` value by replacing all `/` characters with `-`, making it compatible with Docker tag requirements.
* Exported the sanitized `IMAGETAG` for use in subsequent steps and made it available via the GitHub Actions environment (`$GITHUB_ENV`).

**Consistency in image publishing:**

* Updated image publishing logic to use the sanitized and exported `IMAGETAG` consistently, removing redundant re-sanitization and ensuring all references use the correct value.