### PR TITLE
feat(publish-branch): add imagetag input

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: ''
         type: string
+      imagetag:
+        description: "The image tag to use when publishing. Defaults to the branch or tag name that triggered the workflow."
+        required: false
+        type: string
+        default: ${{ github.ref_name }}
     secrets:
       netrcb64:
         description: "Netrc Base64-encoded file content for authenticated downloads. Overrides netrc secret."
@@ -41,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.runner-version }}
     env:
       REPOBASE: ghcr.io/${{ github.repository_owner }}
-      IMAGETAG: ${{ github.ref_name }}
+      IMAGETAG: ${{ inputs.imagetag }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Add a new `imagetag` input to the `publish-branch` workflow, allowing callers to override the image tag instead of always using the branch or tag name. This provides flexibility when publishing images with custom versioning schemes or tags that differ from the Git reference.

Defaults to `github.ref_name` to maintain backward compatibility with existing callers.

## How to test

1. Call `publish-branch.yml` from a downstream repository with the `imagetag` input set
2. Verify the image is published with the custom tag
3. Call without the `imagetag` input and confirm the default behavior (using `github.ref_name`) still works correctly