### PR TITLE
fix(delete-image): fix inert version_id guard in cleanup action

### DIFF
--- a/.github/actions/delete-image/action.yml
+++ b/.github/actions/delete-image/action.yml
@@ -15,7 +15,7 @@ runs:
         for image in ${{ inputs.images }} ; do
           versions_path="${{ github.event.organization.url || github.event.repository.owner.url }}/packages/container/${image}/versions"
           version_id=$(gh api --paginate -q ".[] | select(.metadata.container.tags == [\"${ref}\"]) | .id" ${versions_path})
-          if [[ -n ${version_id}} ]]; then
+          if [[ -n ${version_id} ]]; then
             gh api --input /dev/null -X DELETE ${versions_path}/${version_id}
             echo "::notice::DELETE ${versions_path}/${version_id}"
           fi


### PR DESCRIPTION
Drop the extra brace:

```bash
if [[ -n ${version_id} ]]; then
```

No quotes needed here. `[[ ]]` performs neither word splitting nor globbing, and
an empty expansion stays a valid empty operand, so `-n` is false as intended.

Nothing else changes. Runs that have something to delete keep deleting it. Runs
that have nothing to delete now end green instead of red.